### PR TITLE
fix: Prevent passing invalid values for next_offset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           args: --workspace --all-features --document-private-items --no-deps
 
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -150,7 +150,6 @@ impl<'a> ArroyoConsumer<'a, OwnedMessage> for KafkaConsumer {
                                     NaiveDateTime::from_timestamp(time_millis, 0),
                                     Utc,
                                 ),
-                                None,
                             )))
                         }
                         Err(_) => Err(PollError::ConsumerClosed),

--- a/src/backends/local/broker.rs
+++ b/src/backends/local/broker.rs
@@ -187,7 +187,7 @@ mod tests {
 
         let message = broker.consume(&partition, 0).unwrap().unwrap();
         assert_eq!(message.offset, 0);
-        assert_eq!(message.next_offset, 1);
+        assert_eq!(message.next_offset(), 1);
         assert_eq!(message.payload, "message".to_string());
     }
 

--- a/src/backends/local/mod.rs
+++ b/src/backends/local/mod.rs
@@ -169,7 +169,7 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
             let message = self.broker.consume(partition, offset).unwrap();
             match message {
                 Some(msg) => {
-                    new_offset = Some((partition.clone(), msg.next_offset));
+                    new_offset = Some((partition.clone(), msg.next_offset()));
                     ret_message = Some(msg);
                     break;
                 }
@@ -528,14 +528,14 @@ mod tests {
         assert!(msg1.is_some());
         let msg_content = msg1.unwrap();
         assert_eq!(msg_content.offset, 0);
-        assert_eq!(msg_content.next_offset, 1);
+        assert_eq!(msg_content.next_offset(), 1);
         assert_eq!(msg_content.payload, "message1".to_string());
 
         let msg2 = consumer.poll(Some(0.1)).unwrap();
         assert!(msg2.is_some());
         let msg_content = msg2.unwrap();
         assert_eq!(msg_content.offset, 1);
-        assert_eq!(msg_content.next_offset, 2);
+        assert_eq!(msg_content.next_offset(), 2);
         assert_eq!(msg_content.payload, "message2".to_string());
 
         let ret = consumer.poll(Some(0.1));

--- a/src/backends/storages/memory.rs
+++ b/src/backends/storages/memory.rs
@@ -143,7 +143,6 @@ impl<TPayload: Clone> MessageStorage<TPayload> for MemoryMessageStorage<TPayload
             u64::try_from(offset).unwrap(),
             payload,
             timestamp,
-            None::<u64>,
         ));
         Ok(u64::try_from(offset).unwrap())
     }
@@ -210,7 +209,7 @@ mod tests {
             },
             index: 0,
         };
-        let res = topic.add_message(Message::new(p, 10, "payload".to_string(), now, None::<u64>));
+        let res = topic.add_message(Message::new(p, 10, "payload".to_string(), now));
 
         let p0 = Partition {
             topic: Topic {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -56,7 +56,6 @@ pub struct Message<T: Clone> {
     pub offset: u64,
     pub payload: T,
     pub timestamp: DateTime<Utc>,
-    pub next_offset: u64,
 }
 
 impl<T: Clone> Message<T> {
@@ -66,8 +65,10 @@ impl<T: Clone> Message<T> {
             offset,
             payload,
             timestamp,
-            next_offset: offset + 1,
         }
+    }
+    pub fn next_offset(&self) -> u64 {
+        self.offset + 1
     }
 }
 
@@ -118,7 +119,7 @@ mod tests {
         assert_eq!(message.offset, 10);
         assert_eq!(message.payload, "payload");
         assert_eq!(message.timestamp, now);
-        assert_eq!(message.next_offset, 11)
+        assert_eq!(message.next_offset(), 11)
     }
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -60,22 +60,13 @@ pub struct Message<T: Clone> {
 }
 
 impl<T: Clone> Message<T> {
-    pub fn new(
-        partition: Partition,
-        offset: u64,
-        payload: T,
-        timestamp: DateTime<Utc>,
-        next_offset: Option<u64>,
-    ) -> Self {
+    pub fn new(partition: Partition, offset: u64, payload: T, timestamp: DateTime<Utc>) -> Self {
         Self {
             partition,
             offset,
             payload,
             timestamp,
-            next_offset: match next_offset {
-                Some(v) => v,
-                None => offset + 1,
-            },
+            next_offset: offset + 1,
         }
     }
 }
@@ -87,7 +78,6 @@ impl<T: Clone> Clone for Message<T> {
             self.offset,
             self.payload.clone(),
             self.timestamp,
-            Some(self.next_offset),
         )
     }
 }
@@ -115,33 +105,19 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn message_with_next() {
+    fn message() {
         let now = Utc::now();
         let topic = Topic {
             name: "test".to_string(),
         };
         let part = Partition { topic, index: 10 };
-        let message = Message::new(part, 10, "payload".to_string(), now, Some(20));
+        let message = Message::new(part, 10, "payload".to_string(), now);
 
         assert_eq!(message.partition.topic.name, "test");
         assert_eq!(message.partition.index, 10);
         assert_eq!(message.offset, 10);
         assert_eq!(message.payload, "payload");
         assert_eq!(message.timestamp, now);
-        assert_eq!(message.next_offset, 20)
-    }
-
-    #[test]
-    fn message_without_next() {
-        let now = Utc::now();
-        let part = Partition {
-            topic: Topic {
-                name: "test".to_string(),
-            },
-            index: 10,
-        };
-        let message = Message::new(part, 10, "payload".to_string(), now, None::<u64>);
-
         assert_eq!(message.next_offset, 11)
     }
 
@@ -154,7 +130,7 @@ mod tests {
             },
             index: 10,
         };
-        let message = Message::new(part, 10, "payload".to_string(), now, None::<u64>);
+        let message = Message::new(part, 10, "payload".to_string(), now);
 
         assert_eq!(
             message.to_string(),
@@ -207,7 +183,7 @@ mod tests {
         assert_ne!(&part as *const Partition, &part2 as *const Partition);
 
         let now = Utc::now();
-        let message = Message::new(part, 10, "payload".to_string(), now, None::<u64>);
+        let message = Message::new(part, 10, "payload".to_string(), now);
         let message2 = message.clone();
 
         assert_eq!(message, message2);


### PR DESCRIPTION
Arroyo's next_offset (used for seeking and committing on the consumer)
must always be equal to the offset of the last processed message + 1.
We should not allow any other value to be passed here by the user.
We should also update the Python version of the library to do the same.