### PR TITLE
feat: Avoid double copies

### DIFF
--- a/examples/base_processor.rs
+++ b/examples/base_processor.rs
@@ -1,7 +1,6 @@
 extern crate rust_arroyo;
 
-use rdkafka::message::OwnedMessage;
-use rust_arroyo::backends::kafka::KafkaConsumer;
+use rust_arroyo::backends::kafka::{KafkaConsumer, KafkaPayload};
 use rust_arroyo::processing::strategies::{
     CommitRequest, MessageRejected, ProcessingStrategy, ProcessingStrategyFactory,
 };
@@ -12,7 +11,7 @@ use std::collections::HashMap;
 struct TestStrategy {
     partitions: HashMap<Partition, Position>,
 }
-impl ProcessingStrategy<OwnedMessage> for TestStrategy {
+impl ProcessingStrategy<KafkaPayload> for TestStrategy {
     fn poll(&mut self) -> Option<CommitRequest> {
         println!("POLL");
         if !self.partitions.is_empty() {
@@ -28,7 +27,7 @@ impl ProcessingStrategy<OwnedMessage> for TestStrategy {
         }
     }
 
-    fn submit(&mut self, message: Message<OwnedMessage>) -> Result<(), MessageRejected> {
+    fn submit(&mut self, message: Message<KafkaPayload>) -> Result<(), MessageRejected> {
         println!("SUBMIT {}", message);
         self.partitions.insert(
             message.partition,
@@ -50,8 +49,8 @@ impl ProcessingStrategy<OwnedMessage> for TestStrategy {
 }
 
 struct TestFactory {}
-impl ProcessingStrategyFactory<OwnedMessage> for TestFactory {
-    fn create(&self) -> Box<dyn ProcessingStrategy<OwnedMessage>> {
+impl ProcessingStrategyFactory<KafkaPayload> for TestFactory {
+    fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
         Box::new(TestStrategy {
             partitions: HashMap::new(),
         })

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -8,12 +8,41 @@ use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::base_consumer::BaseConsumer;
 use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
 use rdkafka::error::KafkaResult;
-use rdkafka::message::{Message, OwnedMessage};
+use rdkafka::message::{BorrowedHeaders, BorrowedMessage, Message, OwnedHeaders};
 use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Mutex;
 use std::time::Duration;
+
+#[derive(Clone)]
+pub struct KafkaPayload {
+    pub key: Option<Vec<u8>>,
+    pub headers: Option<OwnedHeaders>,
+    pub payload: Option<Vec<u8>>,
+}
+
+fn create_kafka_message(msg: BorrowedMessage) -> ArroyoMessage<KafkaPayload> {
+    let topic = Topic {
+        name: msg.topic().to_string(),
+    };
+    let partition = Partition {
+        topic,
+        index: msg.partition() as u16,
+    };
+    let time_millis = msg.timestamp().to_millis().unwrap_or(0);
+
+    ArroyoMessage::new(
+        partition,
+        msg.offset() as u64,
+        KafkaPayload {
+            key: msg.key().map(|k| k.to_vec()),
+            headers: msg.headers().map(BorrowedHeaders::detach),
+            payload: msg.payload().map(|p| p.to_vec()),
+        },
+        DateTime::from_utc(NaiveDateTime::from_timestamp(time_millis, 0), Utc),
+    )
+}
 
 struct CustomContext {
     // This is horrible. I want to mutate callbacks (to invoke on_assign)
@@ -95,7 +124,7 @@ impl KafkaConsumer {
     }
 }
 
-impl<'a> ArroyoConsumer<'a, OwnedMessage> for KafkaConsumer {
+impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
     fn subscribe(
         &mut self,
         topics: &[Topic],
@@ -124,7 +153,7 @@ impl<'a> ArroyoConsumer<'a, OwnedMessage> for KafkaConsumer {
         Ok(())
     }
 
-    fn poll(&mut self, _: Option<f64>) -> Result<Option<ArroyoMessage<OwnedMessage>>, PollError> {
+    fn poll(&mut self, _: Option<f64>) -> Result<Option<ArroyoMessage<KafkaPayload>>, PollError> {
         match self.consumer.as_mut() {
             None => Err(PollError::ConsumerClosed),
             Some(consumer) => {
@@ -132,26 +161,7 @@ impl<'a> ArroyoConsumer<'a, OwnedMessage> for KafkaConsumer {
                 match res {
                     None => Ok(None),
                     Some(res) => match res {
-                        Ok(msg) => {
-                            let owned = msg.detach();
-                            let topic = Topic {
-                                name: owned.topic().to_string(),
-                            };
-                            let partition = Partition {
-                                topic,
-                                index: owned.partition() as u16,
-                            };
-                            let time_millis = owned.timestamp().to_millis().unwrap_or(0);
-                            Ok(Some(ArroyoMessage::new(
-                                partition,
-                                owned.offset() as u64,
-                                owned,
-                                DateTime::from_utc(
-                                    NaiveDateTime::from_timestamp(time_millis, 0),
-                                    Utc,
-                                ),
-                            )))
-                        }
+                        Ok(msg) => Ok(Some(create_kafka_message(msg))),
                         Err(_) => Err(PollError::ConsumerClosed),
                     },
                 }


### PR DESCRIPTION
Previously we were keeping two copies of the topic, partition, offset
and timestamp with every message (once in the ArroyoMessage and once
inside the payload field).