### PR TITLE
feat: Poll duration for Kafka backend

### DIFF
--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -124,11 +124,16 @@ impl<'a> ArroyoConsumer<'a, OwnedMessage> for KafkaConsumer {
         Ok(())
     }
 
-    fn poll(&mut self, _: Option<f64>) -> Result<Option<ArroyoMessage<OwnedMessage>>, PollError> {
+    fn poll(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> Result<Option<ArroyoMessage<OwnedMessage>>, PollError> {
+        let duration = timeout.unwrap_or(Duration::from_millis(100));
+
         match self.consumer.as_mut() {
             None => Err(PollError::ConsumerClosed),
             Some(consumer) => {
-                let res = consumer.poll(Duration::from_secs(1));
+                let res = consumer.poll(duration);
                 match res {
                     None => Ok(None),
                     Some(res) => match res {

--- a/src/backends/local/mod.rs
+++ b/src/backends/local/mod.rs
@@ -129,7 +129,7 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
         Ok(())
     }
 
-    fn poll(&mut self, timeout: Option<Duration>) -> Result<Option<Message<TPayload>>, PollError> {
+    fn poll(&mut self, _timeout: Option<Duration>) -> Result<Option<Message<TPayload>>, PollError> {
         if self.closed {
             return Err(PollError::ConsumerClosed);
         }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,5 +1,6 @@
 use super::types::{Message, Partition, Position, Topic};
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 pub mod kafka;
 pub mod local;
@@ -92,7 +93,7 @@ pub trait Consumer<'a, TPayload: Clone> {
     /// consumer attempts to read from an invalid location in one of it's
     /// assigned partitions. (Additional details can be found in the
     /// docstring for ``Consumer.seek``.)
-    fn poll(&mut self, timeout: Option<f64>) -> Result<Option<Message<TPayload>>, PollError>;
+    fn poll(&mut self, timeout: Option<Duration>) -> Result<Option<Message<TPayload>>, PollError>;
 
     /// Pause consuming from the provided partitions.
     ///

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -5,6 +5,7 @@ use crate::types::{Message, Partition, Topic};
 use std::collections::HashMap;
 use std::mem::replace;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use strategies::{ProcessingStrategy, ProcessingStrategyFactory};
 
 #[derive(Debug, Clone)]
@@ -103,7 +104,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
         if message_carried_over {
             // If a message was carried over from the previous run, the consumer
             // should be paused and not returning any messages on ``poll``.
-            let res = self.consumer.poll(Some(0.0)).unwrap();
+            let res = self.consumer.poll(Some(Duration::ZERO)).unwrap();
             match res {
                 None => {}
                 Some(_) => return Err(RunError::InvalidState),
@@ -111,7 +112,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
         } else {
             // Otherwise, we need to try fetch a new message from the consumer,
             // even if there is no active assignment and/or processing strategy.
-            let msg = self.consumer.poll(Some(1.0));
+            let msg = self.consumer.poll(Some(Duration::from_secs(1)));
             //TODO: Support errors properly
             match msg {
                 Ok(m) => self.message = m,


### PR DESCRIPTION
If a poll duration is passed to the Kafka backend, it is now respected
rather than using the hardcoded 1 second value.

The default poll timeout for the Kafka backend is also updated to 100 milliseconds
instead of 1 second to match the default in the Python arroyo library.

This also changes the signature of the poll method to take a duration instead
of a float that needs to be converted to a duration each time we call poll.
Passing a duration seems less ambiguous that passing an f64 here.