### PR TITLE
feat: Rename `commit_positions`

### DIFF
--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -200,7 +200,7 @@ impl<'a> ArroyoConsumer<'a, OwnedMessage> for KafkaConsumer {
         Ok(())
     }
 
-    fn commit_position(&mut self) -> Result<HashMap<Partition, Position>, ConsumerClosed> {
+    fn commit_positions(&mut self) -> Result<HashMap<Partition, Position>, ConsumerClosed> {
         let mut map = HashMap::new();
         for (partition, position) in self.staged_offsets.iter() {
             map.insert(

--- a/src/backends/local/mod.rs
+++ b/src/backends/local/mod.rs
@@ -273,7 +273,7 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
         Ok(())
     }
 
-    fn commit_position(&mut self) -> Result<HashMap<Partition, Position>, ConsumerClosed> {
+    fn commit_positions(&mut self) -> Result<HashMap<Partition, Position>, ConsumerClosed> {
         if self.closed {
             return Err(ConsumerClosed);
         }
@@ -594,7 +594,7 @@ mod tests {
         let stage_result = consumer.stage_positions(positions.clone());
         assert!(stage_result.is_ok());
 
-        let offsets = consumer.commit_position();
+        let offsets = consumer.commit_positions();
         assert!(offsets.is_ok());
         assert_eq!(offsets.unwrap(), positions);
     }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -149,7 +149,7 @@ pub trait Consumer<'a, TPayload: Clone> {
 
     /// Commit staged offsets. The return value of this method is a mapping
     /// of streams with their committed offsets as values.
-    fn commit_position(&mut self) -> Result<HashMap<Partition, Position>, ConsumerClosed>;
+    fn commit_positions(&mut self) -> Result<HashMap<Partition, Position>, ConsumerClosed>;
 
     fn close(&mut self, timeout: Option<f64>);
 

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -132,7 +132,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
                     None => {}
                     Some(request) => {
                         self.consumer.stage_positions(request.positions).unwrap();
-                        self.consumer.commit_position().unwrap();
+                        self.consumer.commit_positions().unwrap();
                     }
                 };
 


### PR DESCRIPTION
Renames `commit_position` to `commit_positions` in line with `stage_positions`
(as well as the Python version of this library).