### PR TITLE
feat: Avoid clone in `stage_positions`

### DIFF
--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -193,9 +193,8 @@ impl<'a> ArroyoConsumer<'a, OwnedMessage> for KafkaConsumer {
         &mut self,
         positions: HashMap<Partition, Position>,
     ) -> Result<(), ConsumeError> {
-        for (partition, position) in positions.iter() {
-            self.staged_offsets
-                .insert(partition.clone(), position.clone());
+        for (partition, position) in positions {
+            self.staged_offsets.insert(partition, position);
         }
         Ok(())
     }


### PR DESCRIPTION
Since we already cloned the positions before passing them to this
function, let's skip the extra clone here.