### PR TITLE
feat: Add functions to build Kafka configuration

### DIFF
--- a/examples/base_consumer.rs
+++ b/examples/base_consumer.rs
@@ -18,6 +18,8 @@ fn main() {
         vec!["localhost:9092".to_string()],
         "my_group".to_string(),
         "latest".to_string(),
+        false,
+        None,
     );
     let mut consumer = KafkaConsumer::new(config);
     let topic = Topic {

--- a/examples/base_consumer.rs
+++ b/examples/base_consumer.rs
@@ -1,5 +1,6 @@
 extern crate rust_arroyo;
 
+use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::backends::AssignmentCallbacks;
 use rust_arroyo::backends::Consumer;
@@ -13,14 +14,12 @@ impl AssignmentCallbacks for EmptyCallbacks {
 }
 
 fn main() {
-    let config = HashMap::from([
-        ("group.id".to_string(), "my_group".to_string()),
-        (
-            "bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        ),
-    ]);
-    let mut consumer = KafkaConsumer::new("my_group".to_string(), config);
+    let config = KafkaConfig::new_consumer_config(
+        vec!["localhost:9092".to_string()],
+        "my_group".to_string(),
+        "latest".to_string(),
+    );
+    let mut consumer = KafkaConsumer::new(config);
     let topic = Topic {
         name: "test_static".to_string(),
     };

--- a/examples/base_processor.rs
+++ b/examples/base_processor.rs
@@ -63,6 +63,8 @@ fn main() {
         vec!["localhost:9092".to_string()],
         "my_group".to_string(),
         "latest".to_string(),
+        false,
+        None,
     );
     let consumer = Box::new(KafkaConsumer::new(config));
     let topic = Topic {

--- a/examples/base_processor.rs
+++ b/examples/base_processor.rs
@@ -1,5 +1,6 @@
 extern crate rust_arroyo;
 
+use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::{KafkaConsumer, KafkaPayload};
 use rust_arroyo::processing::strategies::{
     CommitRequest, MessageRejected, ProcessingStrategy, ProcessingStrategyFactory,
@@ -58,15 +59,12 @@ impl ProcessingStrategyFactory<KafkaPayload> for TestFactory {
 }
 
 fn main() {
-    let config = HashMap::from([
-        ("group.id".to_string(), "my_group".to_string()),
-        (
-            "bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        ),
-        ("enable.auto.commit".to_string(), "false".to_string()),
-    ]);
-    let consumer = Box::new(KafkaConsumer::new("my_group".to_string(), config));
+    let config = KafkaConfig::new_consumer_config(
+        vec!["localhost:9092".to_string()],
+        "my_group".to_string(),
+        "latest".to_string(),
+    );
+    let consumer = Box::new(KafkaConsumer::new(config));
     let topic = Topic {
         name: "test_static".to_string(),
     };

--- a/src/backends/kafka/config.rs
+++ b/src/backends/kafka/config.rs
@@ -17,9 +17,7 @@ impl KafkaConfig {
         let mut config_map = HashMap::new();
         config_map.insert("bootstrap.servers".to_string(), bootstrap_servers.join(","));
 
-        let config = Self {
-            config_map: config_map,
-        };
+        let config = Self { config_map };
 
         apply_override_params(config, override_params)
     }

--- a/src/backends/kafka/config.rs
+++ b/src/backends/kafka/config.rs
@@ -1,0 +1,89 @@
+use rdkafka::config::ClientConfig as RdKafkaConfig;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct KafkaConfig {
+    config_map: HashMap<String, String>,
+}
+
+impl KafkaConfig {
+    pub fn new_config(bootstrap_servers: Vec<String>) -> Self {
+        let mut config = HashMap::new();
+        config.insert("bootstrap.servers".to_string(), bootstrap_servers.join(","));
+
+        Self { config_map: config }
+    }
+
+    pub fn new_consumer_config(
+        bootstrap_servers: Vec<String>,
+        group_id: String,
+        auto_offset_reset: String,
+    ) -> Self {
+        let mut config = KafkaConfig::new_config(bootstrap_servers);
+        config.config_map.insert("group.id".to_string(), group_id);
+        config
+            .config_map
+            .insert("enable.auto.commit".to_string(), "false".to_string());
+        config.config_map.insert(
+            "auto.offset.reset".to_string(),
+            auto_offset_reset.to_string(),
+        );
+        config
+    }
+
+    pub fn new_producer_config(bootstrap_servers: Vec<String>) -> Self {
+        KafkaConfig::new_config(bootstrap_servers)
+    }
+
+    pub fn set_queued_max_messages_kbytes(&mut self, max_messages_kbytes: u32) {
+        // Consumer configuration
+        self.config_map.insert(
+            "queued.max.messages.kbytes".to_string(),
+            max_messages_kbytes.to_string(),
+        );
+    }
+
+    pub fn set_min_messages(&mut self, min_messages: u32) {
+        // Consumer configuration
+        self.config_map
+            .insert("queued.min.messages".to_string(), min_messages.to_string());
+    }
+
+    pub fn set_strict_offset_reset(&mut self, _strict_offset_reset: bool) {
+        // Consumer configuration
+        unimplemented!();
+    }
+
+    pub fn set_override_param(&mut self, param: String, value: String) {
+        self.config_map.insert(param, value);
+    }
+}
+
+impl From<KafkaConfig> for RdKafkaConfig {
+    fn from(item: KafkaConfig) -> Self {
+        let mut config_obj = RdKafkaConfig::new();
+        for (key, val) in item.config_map.iter() {
+            config_obj.set(key, val);
+        }
+        config_obj
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KafkaConfig;
+    use rdkafka::config::ClientConfig as RdKafkaConfig;
+
+    #[test]
+    fn test_build_consumer_configuration() {
+        let mut config = KafkaConfig::new_consumer_config(
+            vec!["localhost:9092".to_string()],
+            "my-group".to_string(),
+            "error".to_string(),
+        );
+
+        config.set_min_messages(100_000);
+        config.set_queued_max_messages_kbytes(1_000_000);
+        let _: RdKafkaConfig = config.into();
+    }
+}

--- a/src/backends/kafka/config.rs
+++ b/src/backends/kafka/config.rs
@@ -27,10 +27,9 @@ impl KafkaConfig {
         config
             .config_map
             .insert("enable.auto.commit".to_string(), "false".to_string());
-        config.config_map.insert(
-            "auto.offset.reset".to_string(),
-            auto_offset_reset.to_string(),
-        );
+        config
+            .config_map
+            .insert("auto.offset.reset".to_string(), auto_offset_reset);
         config.config_map.insert(
             "queued.max.messages.kbytes".to_string(),
             DEFAULT_QUEUED_MAX_MESSAGE_KBYTES.to_string(),

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -284,6 +284,8 @@ mod tests {
             vec!["localhost:9092".to_string()],
             "my-group".to_string(),
             "latest".to_string(),
+            false,
+            None,
         );
         let mut consumer = KafkaConsumer::new(configuration);
         let topic = Topic {
@@ -302,6 +304,8 @@ mod tests {
             vec!["localhost:9092".to_string()],
             "my-group".to_string(),
             "latest".to_string(),
+            false,
+            None,
         );
         let mut consumer = KafkaConsumer::new(configuration);
         let topic = Topic {


### PR DESCRIPTION
Also removes the group_id as an argument from the consumer as passing it
twice (in both config and directly to consumer) is redundant.