### PR TITLE
ref: Remove lifetime annotations from ArroyoConsumer

### DIFF
--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -124,7 +124,7 @@ impl KafkaConsumer {
     }
 }
 
-impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
+impl ArroyoConsumer<KafkaPayload> for KafkaConsumer {
     fn subscribe(
         &mut self,
         topics: &[Topic],

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -77,7 +77,7 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// occurs even if the consumer retains ownership of the partition across
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
-pub trait Consumer<'a, TPayload: Clone> {
+pub trait Consumer<TPayload: Clone> {
     fn subscribe(
         &mut self,
         topic: &[Topic],

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -68,7 +68,7 @@ impl<TPayload: Clone> Callbacks<TPayload> {
 /// strategies are instantiated on partition assignment and closed on
 /// partition revocation.
 pub struct StreamProcessor<'a, TPayload: Clone> {
-    consumer: Box<dyn Consumer<'a, TPayload> + 'a>,
+    consumer: Box<dyn Consumer<TPayload> + 'a>,
     strategies: Arc<Mutex<Strategies<TPayload>>>,
     message: Option<Message<TPayload>>,
     shutdown_requested: bool,
@@ -76,7 +76,7 @@ pub struct StreamProcessor<'a, TPayload: Clone> {
 
 impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
     pub fn new(
-        consumer: Box<dyn Consumer<'a, TPayload> + 'a>,
+        consumer: Box<dyn Consumer<TPayload> + 'a>,
         processing_factory: Box<dyn ProcessingStrategyFactory<TPayload>>,
     ) -> Self {
         let strategies = Arc::new(Mutex::new(Strategies {
@@ -278,7 +278,7 @@ mod tests {
         let mut broker = build_broker();
         let consumer = Box::new(LocalConsumer::new(
             Uuid::nil(),
-            &mut broker,
+            broker,
             "test_group".to_string(),
             false,
         ));
@@ -306,7 +306,7 @@ mod tests {
 
         let consumer = Box::new(LocalConsumer::new(
             Uuid::nil(),
-            &mut broker,
+            broker,
             "test_group".to_string(),
             false,
         ));


### PR DESCRIPTION
This is an attempt to simplify the ArroyoConsumer lifetimes by
changing the LocalConsumer to have ownership of the LocalBroker.

Since this consumer/broker only used in place of the KafkaConsumer
for testing, I think this change is fairly harmless as it's not
required for the broker to live outside the consumer.