### PR TITLE
feat(build): Build binary for consumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ chrono = "0.4.11"
 uuid = "0.8"
 by_address = "1.0.4"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
+
+[[bin]]
+name = "errors-consumer"
+path = "src/bin/consumer/errors.rs"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,13 @@ format:
 	cargo +stable fmt --all
 .PHONY: format
 
+build: setup-git
+	cargo +stable build
+.PHONY: build
+
+release: setup-git
+	@cargo +stable build --release
+.PHONY: release
 
 setup-git: .git/hooks/pre-commit
 .PHONY: setup-git

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: setup-git
 .PHONY: build
 
 release: setup-git
-	@cargo +stable build --release
+	cargo +stable build --release
 .PHONY: release
 
 setup-git: .git/hooks/pre-commit

--- a/src/bin/consumer/errors.rs
+++ b/src/bin/consumer/errors.rs
@@ -1,5 +1,6 @@
 extern crate rust_arroyo;
 
+use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::backends::AssignmentCallbacks;
 use rust_arroyo::backends::Consumer;
@@ -13,14 +14,14 @@ impl AssignmentCallbacks for EmptyCallbacks {
 }
 
 fn main() {
-    let config = HashMap::from([
-        ("group.id".to_string(), "my_group".to_string()),
-        (
-            "bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        ),
-    ]);
-    let mut consumer = KafkaConsumer::new("my_group".to_string(), config);
+    let config = KafkaConfig::new_consumer_config(
+        vec!["localhost:9092".to_string()],
+        "my_group".to_string(),
+        "latest".to_string(),
+        false,
+        None,
+    );
+    let mut consumer = KafkaConsumer::new(config);
     let topic = Topic {
         name: "test_static".to_string(),
     };

--- a/src/bin/consumer/errors.rs
+++ b/src/bin/consumer/errors.rs
@@ -1,0 +1,40 @@
+extern crate rust_arroyo;
+
+use rust_arroyo::backends::kafka::KafkaConsumer;
+use rust_arroyo::backends::AssignmentCallbacks;
+use rust_arroyo::backends::Consumer;
+use rust_arroyo::types::{Partition, Topic};
+use std::collections::HashMap;
+
+struct EmptyCallbacks {}
+impl AssignmentCallbacks for EmptyCallbacks {
+    fn on_assign(&mut self, _: HashMap<Partition, u64>) {}
+    fn on_revoke(&mut self, _: Vec<Partition>) {}
+}
+
+fn main() {
+    let config = HashMap::from([
+        ("group.id".to_string(), "my_group".to_string()),
+        (
+            "bootstrap.servers".to_string(),
+            "localhost:9092".to_string(),
+        ),
+    ]);
+    let mut consumer = KafkaConsumer::new("my_group".to_string(), config);
+    let topic = Topic {
+        name: "test_static".to_string(),
+    };
+    let res = consumer.subscribe(&[topic], Box::new(EmptyCallbacks {}));
+    assert!(res.is_ok());
+    println!("Subscribed");
+    for _ in 0..20 {
+        println!("Polling");
+        let res = consumer.poll(None);
+        match res.unwrap() {
+            Some(x) => {
+                println!("MSG {}", x)
+            }
+            None => {}
+        }
+    }
+}


### PR DESCRIPTION
- Adds makefile target to build all project files and build release targets.
- Changes to allow building binary for consumers. Code in examples
directory cannot be built with `--release` option. We need to build
binaries with that option for performance runs.