### PR TITLE
test: Add test for commit function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
 
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,25 @@ jobs:
         with:
           key: ${{ github.job }}
 
+      - name: Run Zookeeper and Kafka
+        run: |
+          docker run \
+            --name sentry_zookeeper \
+            -d --network host \
+            -e ZOOKEEPER_CLIENT_PORT=2181 \
+            confluentinc/cp-zookeeper:6.2.0
+
+          docker run \
+            --name sentry_kafka \
+            -d --network host \
+            -e KAFKA_ZOOKEEPER_CONNECT=127.0.0.1:2181 \
+            -e KAFKA_LISTENERS=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092 \
+            -e KAFKA_ADVERTISED_LISTENERS=INTERNAL://127.0.0.1:9093,EXTERNAL://127.0.0.1:9092 \
+            -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
+            -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
+            -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+            confluentinc/cp-kafka:6.2.0
+
       - name: Run Cargo Tests
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ uuid = "0.8"
 by_address = "1.0.4"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 thiserror = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1.19.2", features = ["full"] }

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -271,13 +271,54 @@ mod tests {
     use super::{AssignmentCallbacks, KafkaConsumer};
     use crate::backends::kafka::config::KafkaConfig;
     use crate::backends::Consumer;
-    use crate::types::{Partition, Topic};
+    use crate::types::{Partition, Position, Topic};
+    use chrono::Utc;
+    use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+    use rdkafka::config::ClientConfig;
     use std::collections::HashMap;
 
     struct EmptyCallbacks {}
     impl AssignmentCallbacks for EmptyCallbacks {
         fn on_assign(&mut self, _: HashMap<Partition, u64>) {}
         fn on_revoke(&mut self, _: Vec<Partition>) {}
+    }
+
+    async fn create_topic(topic_name: &str, partition_count: i32) {
+        let config = HashMap::from([(
+            "bootstrap.servers".to_string(),
+            "localhost:9092".to_string(),
+        )]);
+
+        let mut config_obj = ClientConfig::new();
+        for (key, val) in config.iter() {
+            config_obj.set(key, val);
+        }
+
+        let client: AdminClient<_> = config_obj.create().unwrap();
+        let topics = [NewTopic::new(
+            topic_name,
+            partition_count,
+            TopicReplication::Fixed(1),
+        )];
+        client
+            .create_topics(&topics, &AdminOptions::new())
+            .await
+            .unwrap();
+    }
+    async fn delete_topic(topic_name: &str) {
+        let config = HashMap::from([(
+            "bootstrap.servers".to_string(),
+            "localhost:9092".to_string(),
+        )]);
+        let mut config_obj = ClientConfig::new();
+        for (key, val) in config.iter() {
+            config_obj.set(key, val);
+        }
+        let client: AdminClient<_> = config_obj.create().unwrap();
+        client
+            .delete_topics(&[topic_name], &AdminOptions::new())
+            .await
+            .unwrap();
     }
 
     #[test]
@@ -297,8 +338,42 @@ mod tests {
         consumer.subscribe(&[topic], my_callbacks).unwrap();
     }
 
-    #[test]
-    fn test_commit() {}
+    #[tokio::test]
+    async fn test_commit() {
+        create_topic("test", 1).await;
+
+        let configuration = KafkaConfig::new_consumer_config(
+            vec!["localhost:9092".to_string()],
+            "my-group".to_string(),
+            "latest".to_string(),
+            false,
+            None,
+        );
+
+        let mut consumer = KafkaConsumer::new(configuration);
+        let topic = Topic {
+            name: "test".to_string(),
+        };
+        let positions = HashMap::from([(
+            Partition {
+                topic: topic.clone(),
+                index: 0,
+            },
+            Position {
+                offset: 100,
+                timestamp: Utc::now(),
+            },
+        )]);
+
+        let my_callbacks: Box<dyn AssignmentCallbacks> = Box::new(EmptyCallbacks {});
+        consumer.subscribe(&[topic], my_callbacks).unwrap();
+
+        consumer.stage_positions(positions.clone()).unwrap();
+        let res = consumer.commit_positions().unwrap();
+
+        assert_eq!(res, positions);
+        delete_topic("test").await;
+    }
 
     #[test]
     fn test_tell() {


### PR DESCRIPTION
Adds an end to end test for committing offsets in the Kafka consumer. Also adds helper functions for creating and deleting Kafka topics. Needs a running Kafka on `localhost:9092` to work.

Now we run Kafka and Zookeeper in CI. Since docker is not available in macos, removed that test suite.