### PR TITLE
feat: Implement unsubscribe(), close(), and closed()

### DIFF
--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -165,6 +165,12 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
     }
 
     fn unsubscribe(&mut self) -> Result<(), ConsumerError> {
+        let consumer = self
+            .consumer
+            .as_mut()
+            .ok_or(ConsumerError::ConsumerClosed)?;
+        consumer.unsubscribe();
+
         Ok(())
     }
 
@@ -256,13 +262,13 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
         Ok(prev_offsets)
     }
 
-    fn close(&mut self, _: Option<f64>) {
-        //TODO: Implement this
+    fn close(&mut self) {
+        self.state = KafkaConsumerState::Closed;
+        self.consumer = None;
     }
 
     fn closed(&self) -> bool {
-        //TODO: Implement this
-        false
+        self.state == KafkaConsumerState::Closed
     }
 }
 

--- a/src/backends/local/mod.rs
+++ b/src/backends/local/mod.rs
@@ -273,7 +273,7 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
         Ok(positions)
     }
 
-    fn close(&mut self, _: Option<f64>) {
+    fn close(&mut self) {
         let partitions = self
             .broker
             .unsubscribe(self.id, self.group.clone())

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -144,7 +144,7 @@ pub trait Consumer<'a, TPayload: Clone> {
     /// of streams with their committed offsets as values.
     fn commit_positions(&mut self) -> Result<HashMap<Partition, Position>, ConsumerError>;
 
-    fn close(&mut self, timeout: Option<f64>);
+    fn close(&mut self);
 
     fn closed(&self) -> bool;
 }

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -183,7 +183,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
                             strategy.terminate();
                         }
                     }
-                    self.consumer.close(None);
+                    self.consumer.close();
                     return Err(e);
                 }
             }
@@ -197,7 +197,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
     }
 
     pub fn shutdown(&mut self) {
-        self.consumer.close(None);
+        self.consumer.close();
     }
 
     pub fn tell(self) -> HashMap<Partition, u64> {


### PR DESCRIPTION
Add implementations for the following methods to the Kafka consumer
- unsubscribe()
- close()
- closed()