### PR TITLE
feat(metrics): Rudimentary metrics client implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ uuid = "0.8"
 by_address = "1.0.4"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 thiserror = "1.0"
+clap = "2.18.0"
 tokio = { version = "1.19.2", features = ["full"] }
 futures = "0.3.21"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = "1.0"
 cadence = "0.29.0"
 lazy_static = "1.4.0"
 parking_lot = "0.10.0"
+rand="0.8.5"
 
 [dev-dependencies]
 tokio = { version = "1.19.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ uuid = "0.8"
 by_address = "1.0.4"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 thiserror = "1.0"
+cadence = "0.29.0"
+lazy_static = "1.4.0"
+parking_lot = "0.10.0"
 
 [dev-dependencies]
 tokio = { version = "1.19.2", features = ["full"] }

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -206,14 +206,11 @@ mod tests {
     fn test_metrics() {
         init("my_host", "0.0.0.0:8125");
 
-        assert_eq!(
-            METRICS_CLIENT
-                .read()
-                .clone()
-                .unwrap()
-                .should_sample(Some(0.0)),
-            false,
-        );
+        assert!(!METRICS_CLIENT
+            .read()
+            .clone()
+            .unwrap()
+            .should_sample(Some(0.0)),);
         assert!(METRICS_CLIENT
             .read()
             .clone()

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -1,6 +1,4 @@
-use cadence::{
-    BufferedUdpMetricSink, Counted, Gauged, QueuingMetricSink, StatsdClient, Timed, UdpMetricSink,
-};
+use cadence::{BufferedUdpMetricSink, Counted, Gauged, QueuingMetricSink, StatsdClient, Timed};
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use std::collections::HashMap;
@@ -124,6 +122,7 @@ pub fn init<A: ToSocketAddrs>(prefix: &str, host: A) {
         statsd_client,
         prefix: String::from(prefix),
     };
+    println!("Emitting metrics with prefix {}", metrics_client.prefix);
     *METRICS_CLIENT.write() = Some(Arc::new(metrics_client));
 }
 

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -20,15 +20,17 @@ pub struct MetricsClient {
 
 impl Metrics for MetricsClient {
     fn counter(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
-        let count_value: i64;
-        if value.is_none() {
-            count_value = 1;
-        } else {
-            count_value = value.unwrap();
+        let mut count_value: i64 = 1;
+        if let Some(value) = value {
+            count_value = value;
         }
 
-        if tags.is_none() {
-            let result = self.statsd_client.count(key, count_value);
+        if let Some(tags) = tags {
+            let mut metric_builder = self.statsd_client.count_with_tags(key, count_value);
+            for (key, value) in tags {
+                metric_builder = metric_builder.with_tag(key, value);
+            }
+            let result = metric_builder.try_send();
             match result {
                 Ok(_) => {}
                 Err(_err) => {
@@ -36,12 +38,7 @@ impl Metrics for MetricsClient {
                 }
             }
         } else {
-            assert!(tags.is_some());
-            let mut metric_builder = self.statsd_client.count_with_tags(key, count_value);
-            for (key, value) in tags.unwrap() {
-                metric_builder = metric_builder.with_tag(key, value);
-            }
-            let result = metric_builder.try_send();
+            let result = self.statsd_client.count(key, count_value);
             match result {
                 Ok(_) => {}
                 Err(_err) => {
@@ -52,8 +49,12 @@ impl Metrics for MetricsClient {
     }
 
     fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
-        if tags.is_none() {
-            let result = self.statsd_client.gauge(key, value);
+        if let Some(tags) = tags {
+            let mut metric_builder = self.statsd_client.gauge_with_tags(key, value);
+            for (key, value) in tags {
+                metric_builder = metric_builder.with_tag(key, value);
+            }
+            let result = metric_builder.try_send();
             match result {
                 Ok(_) => {}
                 Err(_err) => {
@@ -61,12 +62,7 @@ impl Metrics for MetricsClient {
                 }
             }
         } else {
-            assert!(tags.is_some());
-            let mut metric_builder = self.statsd_client.gauge_with_tags(key, value);
-            for (key, value) in tags.unwrap() {
-                metric_builder = metric_builder.with_tag(key, value);
-            }
-            let result = metric_builder.try_send();
+            let result = self.statsd_client.gauge(key, value);
             match result {
                 Ok(_) => {}
                 Err(_err) => {
@@ -77,8 +73,12 @@ impl Metrics for MetricsClient {
     }
 
     fn time(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
-        if tags.is_none() {
-            let result = self.statsd_client.time(key, value);
+        if let Some(tags) = tags {
+            let mut metric_builder = self.statsd_client.time_with_tags(key, value);
+            for (key, value) in tags {
+                metric_builder = metric_builder.with_tag(key, value);
+            }
+            let result = metric_builder.try_send();
             match result {
                 Ok(_) => {}
                 Err(_err) => {
@@ -86,12 +86,7 @@ impl Metrics for MetricsClient {
                 }
             }
         } else {
-            assert!(tags.is_some());
-            let mut metric_builder = self.statsd_client.time_with_tags(key, value);
-            for (key, value) in tags.unwrap() {
-                metric_builder = metric_builder.with_tag(key, value);
-            }
-            let result = metric_builder.try_send();
+            let result = self.statsd_client.time(key, value);
             match result {
                 Ok(_) => {}
                 Err(_err) => {

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -1,0 +1,173 @@
+use cadence::{
+    BufferedUdpMetricSink, Counted, Gauged, QueuingMetricSink, StatsdClient, Timed, UdpMetricSink,
+};
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::net::{ToSocketAddrs, UdpSocket};
+use std::sync::Arc;
+
+pub trait Metrics {
+    fn counter(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>);
+
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
+
+    fn time(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
+}
+
+pub struct MetricsClient {
+    pub statsd_client: StatsdClient,
+    prefix: String,
+}
+
+impl Metrics for MetricsClient {
+    fn counter(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+        let count_value: i64;
+        if value.is_none() {
+            count_value = 1;
+        } else {
+            count_value = value.unwrap();
+        }
+
+        if tags.is_none() {
+            let result = self.statsd_client.count(key, count_value);
+            match result {
+                Ok(_) => {}
+                Err(_err) => {
+                    println!("Failed to send metric {}: {}", key, _err)
+                }
+            }
+        } else {
+            assert!(tags.is_some());
+            let mut metric_builder = self.statsd_client.count_with_tags(key, count_value);
+            for (key, value) in tags.unwrap() {
+                metric_builder = metric_builder.with_tag(key, value);
+            }
+            let result = metric_builder.try_send();
+            match result {
+                Ok(_) => {}
+                Err(_err) => {
+                    println!("Failed to send metric {}: {}", key, _err)
+                }
+            }
+        }
+    }
+
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        if tags.is_none() {
+            let result = self.statsd_client.gauge(key, value);
+            match result {
+                Ok(_) => {}
+                Err(_err) => {
+                    println!("Failed to send metric {}: {}", key, _err)
+                }
+            }
+        } else {
+            assert!(tags.is_some());
+            let mut metric_builder = self.statsd_client.gauge_with_tags(key, value);
+            for (key, value) in tags.unwrap() {
+                metric_builder = metric_builder.with_tag(key, value);
+            }
+            let result = metric_builder.try_send();
+            match result {
+                Ok(_) => {}
+                Err(_err) => {
+                    println!("Failed to send metric {}: {}", key, _err)
+                }
+            }
+        }
+    }
+
+    fn time(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        if tags.is_none() {
+            let result = self.statsd_client.time(key, value);
+            match result {
+                Ok(_) => {}
+                Err(_err) => {
+                    println!("Failed to send metric {}: {}", key, _err)
+                }
+            }
+        } else {
+            assert!(tags.is_some());
+            let mut metric_builder = self.statsd_client.time_with_tags(key, value);
+            for (key, value) in tags.unwrap() {
+                metric_builder = metric_builder.with_tag(key, value);
+            }
+            let result = metric_builder.try_send();
+            match result {
+                Ok(_) => {}
+                Err(_err) => {
+                    println!("Failed to send metric {}: {}", key, _err)
+                }
+            }
+        }
+    }
+}
+
+lazy_static! {
+    static ref METRICS_CLIENT: RwLock<Option<Arc<MetricsClient>>> = RwLock::new(None);
+}
+
+const METRICS_MAX_QUEUE_SIZE: usize = 1024;
+
+pub fn init<A: ToSocketAddrs>(prefix: &str, host: A) {
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    socket.set_nonblocking(true).unwrap();
+
+    let buffered_udp_sink = BufferedUdpMetricSink::from(host, socket).unwrap();
+    let queuing_sink = QueuingMetricSink::with_capacity(buffered_udp_sink, METRICS_MAX_QUEUE_SIZE);
+    // If metrics need to be sent out immediately without waiting then use the udp_sink below.
+    //let udp_sink = UdpMetricSink::from(host, socket).unwrap();
+    let statsd_client = StatsdClient::from_sink(prefix, queuing_sink);
+
+    let metrics_client = MetricsClient {
+        statsd_client,
+        prefix: String::from(prefix),
+    };
+    *METRICS_CLIENT.write() = Some(Arc::new(metrics_client));
+}
+
+// TODO: Remove cloning METRICS_CLIENT each time this is called using thread local storage.
+pub fn increment(key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+    METRICS_CLIENT
+        .read()
+        .clone()
+        .unwrap()
+        .counter(key, value, tags);
+}
+
+// TODO: Remove cloning METRICS_CLIENT each time this is called using thread local storage.
+pub fn gauge(key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    METRICS_CLIENT
+        .read()
+        .clone()
+        .unwrap()
+        .gauge(key, value, tags);
+}
+
+// TODO: Remove cloning METRICS_CLIENT each time this is called using thread local storage.
+pub fn time(key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    METRICS_CLIENT
+        .read()
+        .clone()
+        .unwrap()
+        .time(key, value, tags);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::metrics::{gauge, increment, init, time};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_metrics() {
+        init("my_host", "0.0.0.0:8125");
+        increment("a", Some(1), Some(HashMap::from([("tag1", "value1")])));
+        gauge(
+            "b",
+            20,
+            Some(HashMap::from([("tag2", "value2"), ("tag4", "value4")])),
+        );
+        time("c", 30, Some(HashMap::from([("tag3", "value3")])));
+    }
+}

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -47,7 +47,7 @@ impl Metrics for MetricsClient {
         tags: Option<HashMap<&str, &str>>,
         sample_rate: Option<f64>,
     ) {
-        if self.should_sample(sample_rate) == false {
+        if !self.should_sample(sample_rate) {
             return;
         }
 
@@ -74,7 +74,7 @@ impl Metrics for MetricsClient {
         tags: Option<HashMap<&str, &str>>,
         sample_rate: Option<f64>,
     ) {
-        if self.should_sample(sample_rate) == false {
+        if !self.should_sample(sample_rate) {
             return;
         }
 
@@ -99,7 +99,7 @@ impl Metrics for MetricsClient {
         tags: Option<HashMap<&str, &str>>,
         sample_rate: Option<f64>,
     ) {
-        if self.should_sample(sample_rate) == false {
+        if !self.should_sample(sample_rate) {
             return;
         }
 
@@ -120,11 +120,7 @@ impl Metrics for MetricsClient {
 
 impl MetricsClient {
     fn should_sample(&self, sample_rate: Option<f64>) -> bool {
-        return if rand::thread_rng().gen_range(0.0..=1.0) < sample_rate.unwrap_or(1.0) {
-            true
-        } else {
-            false
-        };
+        rand::thread_rng().gen_range(0.0..=1.0) < sample_rate.unwrap_or(1.0)
     }
 
     fn send_with_tags<'t, T: cadence::Metric + From<String>>(
@@ -216,16 +212,13 @@ mod tests {
                 .clone()
                 .unwrap()
                 .should_sample(Some(0.0)),
-            false
+            false,
         );
-        assert_eq!(
-            METRICS_CLIENT
-                .read()
-                .clone()
-                .unwrap()
-                .should_sample(Some(1.0)),
-            true
-        );
+        assert!(METRICS_CLIENT
+            .read()
+            .clone()
+            .unwrap()
+            .should_sample(Some(1.0)),);
 
         increment(
             "a",

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod clock;
+pub mod metrics;


### PR DESCRIPTION
A rudimentary implementation for supporting metrics using cadence library. Tested locally with a statsd server and was able to verify that metrics get sent.