### PR TITLE
feat(experiment): passthrough consumer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ path = "src/bin/consumer/errors.rs"
 [[bin]]
 name = "passthrough-consumer"
 path = "src/bin/consumer/passthrough.rs"
+
+[[bin]]
+name = "async-sucks"
+path = "src/bin/consumer/async_sucks.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,3 @@ path = "src/bin/consumer/errors.rs"
 [[bin]]
 name = "passthrough-consumer"
 path = "src/bin/consumer/passthrough.rs"
-
-[[bin]]
-name = "async-sucks"
-path = "src/bin/consumer/async_sucks.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,15 @@ uuid = "0.8"
 by_address = "1.0.4"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 thiserror = "1.0"
-
-[dev-dependencies]
+clap = "2.18.0"
 tokio = { version = "1.19.2", features = ["full"] }
+futures = "0.3.21"
+log = "0.4.8"
 
 [[bin]]
 name = "errors-consumer"
 path = "src/bin/consumer/errors.rs"
+
+[[bin]]
+name = "passthrough-consumer"
+path = "src/bin/consumer/passthrough.rs"

--- a/src/bin/consumer/passthrough.rs
+++ b/src/bin/consumer/passthrough.rs
@@ -1,4 +1,6 @@
 use clap::{App, Arg};
+use futures::future::join_all;
+use futures::future::try_join_all;
 use futures::{stream::FuturesUnordered, Future, StreamExt};
 use log::warn;
 use rdkafka::client::ClientContext;
@@ -7,12 +9,17 @@ use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
 use rdkafka::error::KafkaResult;
 use rdkafka::message::Message;
+use rdkafka::message::OwnedMessage;
 use rdkafka::producer::future_producer::OwnedDeliveryResult;
 use rdkafka::producer::DeliveryFuture;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::topic_partition_list::TopicPartitionList;
 use rdkafka::util::get_rdkafka_version;
+use std::boxed::Box;
+use std::rc::Rc;
 use std::time::Duration;
+use tokio::spawn;
+use tokio::sync::mpsc;
 
 // use crate::example_utils::setup_logger;
 
@@ -44,30 +51,15 @@ impl ConsumerContext for CustomContext {
 // A type alias with your custom consumer can be created for convenience.
 type LoggingConsumer = StreamConsumer<CustomContext>;
 
-/*async fn wait_on_batch(batch: &mut FuturesUnordered<Future(Output = OwnedDeliveryResult>)) {
-    // TODO: configurable batch size
-
-    if batch.len() > 10 {
-        for future in batch.iter_mut() {
-            let res = future.await;
-            match res {
-                Ok(msg) => {println!("SUCESS")}
-                Err(e) => {println!("Fail {}", e)}
-            }
-        }
-    }
-}*/
-
-async fn test_async_fn() -> i32 {
-    return 5;
-}
-
-async fn consume_and_print(brokers: &str, group_id: &str, source_topic: &str, dest_topic: &str) {
+async fn consume_and_print(
+    sender: mpsc::Sender<OwnedMessage>,
+    brokers: &str,
+    group_id: &str,
+    source_topic: &str,
+    dest_topic: &str,
+) {
     let context = CustomContext {};
-    // let mut batch = Vec::new();
-
-    let _batch_2 = vec![test_async_fn()];
-    // let batch_3: Vec<Future<Output = i32>> = vec![test_async_fn()];
+    //let mut batch = Vec::new();
 
     let consumer: LoggingConsumer = ClientConfig::new()
         .set("group.id", group_id)
@@ -87,12 +79,6 @@ async fn consume_and_print(brokers: &str, group_id: &str, source_topic: &str, de
         .subscribe(&vec![source_topic])
         .expect("Can't subscribe to specified topics");
 
-    let producer: &FutureProducer = &ClientConfig::new()
-        .set("bootstrap.servers", brokers)
-        .set("message.timeout.ms", "5000")
-        .create()
-        .expect("couldn't create producer");
-
     loop {
         match consumer.recv().await {
             Err(e) => warn!("Kafka error: {}", e),
@@ -107,23 +93,69 @@ async fn consume_and_print(brokers: &str, group_id: &str, source_topic: &str, de
                 };
                 println!("key: '{:?}', payload: '{}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
                       m.key(), payload, m.topic(), m.partition(), m.offset(), m.timestamp());
-                let future_record = FutureRecord::to(dest_topic).payload(payload).key("None");
 
-                let produce_future = producer.send(future_record, Duration::from_secs(0));
-                match produce_future.await {
-                    Ok(_msg) => {
-                        println! {"success"}
-                    }
-                    Err(e) => {
-                        println! {"error {:?}", e}
-                    }
-                }
-
-                /* batch.push(produce_future);
-                wait_on_batch(batch);*/
+                // batch.push(m.detach());
+                sender.send(m.detach()).await.unwrap();
                 consumer.commit_message(&m, CommitMode::Async).unwrap();
             }
         };
+    }
+}
+
+async fn produce_kafka_message<'a>(
+    producer: &'a FutureProducer,
+    record: Box<FutureRecord<'a, String, String>>,
+) -> OwnedDeliveryResult {
+    return producer.send(*record, Duration::from_secs(0)).await;
+}
+
+async fn produce_messages(
+    mut rx: mpsc::Receiver<OwnedMessage>,
+    brokers: String,
+    dest_topic: String,
+) {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("couldn't create producer");
+    let mut batch = Vec::new();
+    loop {
+        let m = rx.recv().await.unwrap();
+        let payload = match m.payload() {
+            Some(p) => p,
+            None => panic!("No payload"),
+        };
+        let payload_str = match m.payload_view::<str>() {
+            None => "",
+            Some(Ok(s)) => s,
+            Some(Err(e)) => {
+                warn!("Error while deserializing message payload: {:?}", e);
+                ""
+            }
+        };
+        println!("PRODUCE: key: '{:?}', payload: '{}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
+                      m.key(), payload_str, m.topic(), m.partition(), m.offset(), m.timestamp());
+        let stupid_string = String::from_utf8(payload.to_vec()).unwrap();
+        let key = String::from("None");
+        let tmp_producer = producer.clone();
+        let tmp_dest_topic = dest_topic.clone();
+        batch.push(Box::pin(async move {
+            return tmp_producer
+                .send(
+                    FutureRecord::to(tmp_dest_topic.as_str())
+                        .payload(&stupid_string)
+                        .key(&key),
+                    Duration::from_secs(0),
+                )
+                .await;
+        }));
+        if batch.len() > 10 {
+            for r in try_join_all(batch.iter_mut()).await.iter() {
+                println!("RESULT: {:?}", r);
+            }
+            batch.clear();
+        }
     }
 }
 
@@ -177,6 +209,11 @@ async fn main() {
     let brokers = matches.value_of("brokers").unwrap();
     let group_id = matches.value_of("group-id").unwrap();
     let dest_topic = matches.value_of("dest_topic").unwrap();
-
-    consume_and_print(brokers, group_id, source_topic, dest_topic).await
+    let (sender, receiver) = mpsc::channel::<OwnedMessage>(1000);
+    spawn(produce_messages(
+        receiver,
+        String::from(brokers),
+        String::from(dest_topic),
+    ));
+    consume_and_print(sender, brokers, group_id, source_topic, dest_topic).await
 }

--- a/src/bin/consumer/passthrough.rs
+++ b/src/bin/consumer/passthrough.rs
@@ -55,7 +55,7 @@ async fn flush_batch(
                     let offset_to_commit =
                         match positions.get_mut(&(source_topic.as_str(), *partition)) {
                             None => *position,
-                            Some(v) => max(v.clone(), *position),
+                            Some(v) => max(*v, *position),
                         };
                     match positions.insert((source_topic.as_str(), *partition), offset_to_commit) {
                         Some(_) => {}
@@ -90,7 +90,6 @@ async fn consume_and_produce(
         .set("bootstrap.servers", brokers)
         .set("enable.partition.eof", "false")
         .set("session.timeout.ms", "6000")
-        // TODO: disable auto commit
         .set("enable.auto.commit", "false")
         //.set("statistics.interval.ms", "30000")
         .set("auto.offset.reset", "smallest")
@@ -99,7 +98,7 @@ async fn consume_and_produce(
         .expect("Consumer creation failed");
 
     consumer
-        .subscribe(&vec![source_topic])
+        .subscribe(&[source_topic])
         .expect("Can't subscribe to specified topics");
 
     let producer: FutureProducer = ClientConfig::new()

--- a/src/bin/consumer/passthrough.rs
+++ b/src/bin/consumer/passthrough.rs
@@ -1,0 +1,169 @@
+use clap::{App, Arg};
+use futures::{stream::FuturesUnordered, StreamExt};
+use log::warn;
+use rdkafka::client::ClientContext;
+use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
+use rdkafka::consumer::stream_consumer::StreamConsumer;
+use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
+use rdkafka::error::KafkaResult;
+use rdkafka::message::Message;
+use rdkafka::producer::future_producer::OwnedDeliveryResult;
+use rdkafka::producer::DeliveryFuture;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::topic_partition_list::TopicPartitionList;
+use rdkafka::util::get_rdkafka_version;
+use std::time::Duration;
+
+// use crate::example_utils::setup_logger;
+
+// mod example_utils;
+//
+//
+
+// A context can be used to change the behavior of producers and consumers by adding callbacks
+// that will be executed by librdkafka.
+// This particular context sets up custom callbacks to log rebalancing events.
+struct CustomContext;
+
+impl ClientContext for CustomContext {}
+
+impl ConsumerContext for CustomContext {
+    fn pre_rebalance(&self, rebalance: &Rebalance) {
+        println!("Pre rebalance {:?}", rebalance);
+    }
+
+    fn post_rebalance(&self, rebalance: &Rebalance) {
+        println!("Post rebalance {:?}", rebalance);
+    }
+
+    fn commit_callback(&self, result: KafkaResult<()>, _offsets: &TopicPartitionList) {
+        println!("Committing offsets: {:?}", result);
+    }
+}
+
+// A type alias with your custom consumer can be created for convenience.
+type LoggingConsumer = StreamConsumer<CustomContext>;
+
+async fn wait_on_batch(batch: &mut FuturesUnordered<OwnedDeliveryResult>) {
+    // TODO: configurable batch size
+    if batch.len() > 10 {
+        while let Some(message) = batch.next().await {
+            println!("produced message: {}", message);
+        }
+    }
+}
+
+async fn consume_and_print(brokers: &str, group_id: &str, source_topic: &str, dest_topic: &str) {
+    let context = CustomContext {};
+    let batch = FuturesUnordered::new();
+    // TODO: make this not leak memory infinitely
+    let mut produce_batch: Vec<&str> = Vec::new();
+
+    let consumer: LoggingConsumer = ClientConfig::new()
+        .set("group.id", group_id)
+        .set("bootstrap.servers", brokers)
+        .set("enable.partition.eof", "false")
+        .set("session.timeout.ms", "6000")
+        // TODO: disable auto commit
+        .set("enable.auto.commit", "true")
+        //.set("statistics.interval.ms", "30000")
+        .set("auto.offset.reset", "smallest")
+        // TODO: this should probably not be DEBUG
+        .set_log_level(RDKafkaLogLevel::Debug)
+        .create_with_context(context)
+        .expect("Consumer creation failed");
+
+    consumer
+        .subscribe(&vec![source_topic])
+        .expect("Can't subscribe to specified topics");
+
+    let producer: &FutureProducer = &ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("couldn't create producer");
+
+    loop {
+        match consumer.recv().await {
+            Err(e) => warn!("Kafka error: {}", e),
+            Ok(m) => {
+                let payload = match m.payload_view::<str>() {
+                    None => "",
+                    Some(Ok(s)) => s,
+                    Some(Err(e)) => {
+                        warn!("Error while deserializing message payload: {:?}", e);
+                        ""
+                    }
+                };
+                println!("key: '{:?}', payload: '{}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
+                      m.key(), payload, m.topic(), m.partition(), m.offset(), m.timestamp());
+                let to_send = format!("{}", payload);
+                produce_batch.push(to_send.as_str());
+                let produce_future = producer.send(
+                    FutureRecord::to(dest_topic)
+                        .payload(&produce_batch.last().unwrap())
+                        .key("None"),
+                    Duration::from_secs(0),
+                );
+
+                batch.push(produce_future);
+
+                consumer.commit_message(&m, CommitMode::Async).unwrap();
+            }
+        };
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let matches = App::new("consumer example")
+        .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
+        .about("Simple command line consumer")
+        .arg(
+            Arg::with_name("brokers")
+                .short("b")
+                .long("brokers")
+                .help("Broker list in kafka format")
+                .takes_value(true)
+                .default_value("localhost:9092"),
+        )
+        .arg(
+            Arg::with_name("group-id")
+                .short("g")
+                .long("group-id")
+                .help("Consumer group id")
+                .takes_value(true)
+                .default_value("example_consumer_group_id"),
+        )
+        .arg(
+            Arg::with_name("log-conf")
+                .long("log-conf")
+                .help("Configure the logging format (example: 'rdkafka=trace')")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("source_topic")
+                .long("source")
+                .help("source topic name")
+                .default_value("test_source")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("dest_topic")
+                .long("dest")
+                .help("destination topic name")
+                .default_value("test_dest")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let (version_n, version_s) = get_rdkafka_version();
+    println!("rd_kafka_version: 0x{:08x}, {}", version_n, version_s);
+
+    let source_topic = matches.value_of("source_topic").unwrap();
+    let brokers = matches.value_of("brokers").unwrap();
+    let group_id = matches.value_of("group-id").unwrap();
+    let dest_topic = matches.value_of("dest_topic").unwrap();
+
+    consume_and_print(brokers, group_id, source_topic, dest_topic).await
+}


### PR DESCRIPTION
This PR introduces a passthrough consumer that demonstrates the following things:

* usage of asyncio in rust with kafka
* batching waiting on producer delivery without callback hell

It's there mainly for benchmarking however it's possible to use it as an example of how to make something more sophisticated