### PR TITLE
test: Fix flaky test

### DIFF
--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -442,6 +442,7 @@ mod tests {
         for _ in 0..10 {
             consumer.poll(Some(Duration::from_millis(5_000))).unwrap();
             if consumer.tell().unwrap().len() == 1 {
+                println!("Received assignment");
                 break;
             }
             sleep(Duration::from_millis(200));

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -439,7 +439,7 @@ mod tests {
 
         // Wait until the consumer got an assignment
         for _ in 0..5 {
-            consumer.poll(Some(Duration::from_millis(3_000))).unwrap();
+            consumer.poll(Some(Duration::from_millis(5_000))).unwrap();
             if consumer.tell().unwrap().len() == 1 {
                 break;
             }

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -322,6 +322,7 @@ mod tests {
     use rdkafka::client::DefaultClientContext;
     use rdkafka::config::ClientConfig;
     use std::collections::HashMap;
+    use std::thread::sleep;
     use std::time::Duration;
 
     struct EmptyCallbacks {}
@@ -438,11 +439,12 @@ mod tests {
         consumer.stage_positions(positions.clone()).unwrap();
 
         // Wait until the consumer got an assignment
-        for _ in 0..5 {
+        for _ in 0..10 {
             consumer.poll(Some(Duration::from_millis(5_000))).unwrap();
             if consumer.tell().unwrap().len() == 1 {
                 break;
             }
+            sleep(Duration::from_millis(200));
         }
 
         let res = consumer.commit_positions().unwrap();


### PR DESCRIPTION
Waits for the consumer to receive an assignment before attempting to
commit offsets. Gives up after 10 attempts.

This test is still flaky after this fix however this change appears to reduce the
frequency of failures.