### PR TITLE
feat: Add a script to generate data for local testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ path = "src/bin/consumer/passthrough.rs"
 [[bin]]
 name = "noop-consumer"
 path = "src/bin/consumer/noop.rs"
+
+[[bin]]
+name = "generator"
+path = "src/bin/mocks/generate_data.rs"

--- a/src/backends/kafka/producer.rs
+++ b/src/backends/kafka/producer.rs
@@ -1,9 +1,10 @@
 use crate::backends::kafka::config::KafkaConfig;
 use crate::backends::kafka::types::KafkaPayload;
-use crate::backends::Producer;
+use crate::backends::Producer as ArroyoProducer;
 use crate::types::TopicOrPartition;
 use rdkafka::config::ClientConfig;
-use rdkafka::producer::{BaseProducer, BaseRecord};
+use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
+use std::time::Duration;
 
 pub struct KafkaProducer {
     producer: Option<BaseProducer>,
@@ -20,7 +21,19 @@ impl KafkaProducer {
     }
 }
 
-impl Producer<KafkaPayload> for KafkaProducer {
+impl KafkaProducer {
+    pub fn poll(&self) {
+        let producer = self.producer.as_ref().unwrap();
+        producer.poll(Duration::ZERO);
+    }
+
+    pub fn flush(&self) {
+        let producer = self.producer.as_ref().unwrap();
+        producer.flush(Duration::from_millis(5000));
+    }
+}
+
+impl ArroyoProducer<KafkaPayload> for KafkaProducer {
     fn produce(&self, destination: &TopicOrPartition, payload: &KafkaPayload) {
         let topic = match destination {
             TopicOrPartition::Topic(topic) => topic.name.as_ref(),

--- a/src/bin/mocks/generate_data.rs
+++ b/src/bin/mocks/generate_data.rs
@@ -1,0 +1,92 @@
+extern crate rust_arroyo;
+
+use clap::{App, Arg};
+use futures::executor::block_on;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::client::DefaultClientContext;
+use rdkafka::config::ClientConfig;
+use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::producer::KafkaProducer;
+use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::backends::Producer;
+use rust_arroyo::types::{Topic, TopicOrPartition};
+
+async fn recreate_topic(brokers: &str, topic: &str) {
+    let mut config = ClientConfig::new();
+    config.set("bootstrap.servers".to_string(), brokers);
+
+    let admin_client: AdminClient<DefaultClientContext> = config.create().unwrap();
+
+    admin_client
+        .delete_topics(&[topic], &AdminOptions::new())
+        .await
+        .unwrap();
+
+    let topics = [NewTopic::new(topic, 1, TopicReplication::Fixed(1))];
+    admin_client
+        .create_topics(&topics, &AdminOptions::new())
+        .await
+        .unwrap();
+}
+
+fn generate_metric() -> String {
+    r#"{"org_id": 1, "project_id": 1, "metric_id": 1000, "timestamp:: 1656183801, "tags": {"some_tag": "some_tag_value"}}".to_string()"#.to_string()
+}
+
+fn main() {
+    let matches = App::new("consumer example")
+        .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
+        .about("Simple command line consumer")
+        .arg(
+            Arg::with_name("brokers")
+                .long("brokers")
+                .help("Broker list in kafka format")
+                .takes_value(true)
+                .default_value("localhost:9092"),
+        )
+        .arg(
+            Arg::with_name("topic")
+                .long("topic")
+                .help("Kafka topic")
+                .takes_value(true)
+                .default_value("test_source"),
+        )
+        .arg(
+            Arg::with_name("number")
+                .long("number")
+                .help("number of events to generate")
+                .default_value("1000")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let topic = matches.value_of("topic").unwrap();
+    let brokers = matches.value_of("brokers").unwrap();
+    let number = matches.value_of("number").unwrap().parse::<u32>().unwrap();
+
+    // Deletes and recreates topic
+    block_on(recreate_topic(brokers, topic));
+
+    // Create producer
+    let topic = Topic {
+        name: topic.to_string(),
+    };
+    let destination = TopicOrPartition::Topic(topic);
+    let config = KafkaConfig::new_producer_config(vec!["localhost:9092".to_string()], None);
+
+    let mut producer = KafkaProducer::new(config);
+
+    for _ in 0..number {
+        let payload = KafkaPayload {
+            key: None,
+            headers: None,
+            payload: Some(generate_metric().as_bytes().to_vec()),
+        };
+        producer.produce(&destination, &payload);
+        producer.poll();
+    }
+
+    producer.flush();
+
+    producer.close();
+}


### PR DESCRIPTION
This is intended to be useful for local testing and profiling. It generates
a metrics-like message. The messages are currently all the same. But that
should not make a difference for testing basic consumers.