### PR TITLE
perf: Poll shouldn't block by default

### DIFF
--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -196,7 +196,7 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
     ) -> Result<Option<ArroyoMessage<KafkaPayload>>, ConsumerError> {
         self.state.assert_consuming_state()?;
 
-        let duration = timeout.unwrap_or(Duration::from_millis(100));
+        let duration = timeout.unwrap_or(Duration::ZERO);
         let consumer = self.consumer.as_mut().unwrap();
         let res = consumer.poll(duration);
         match res {


### PR DESCRIPTION
This can be deadly as poll is called on the main thread. Don't wait
if buffers are empty, just return None.