### PR TITLE
test / Fix kafka config

### DIFF
--- a/src/backends/kafka/config.rs
+++ b/src/backends/kafka/config.rs
@@ -1,9 +1,6 @@
 use rdkafka::config::ClientConfig as RdKafkaConfig;
 use std::collections::HashMap;
 
-const DEFAULT_QUEUED_MAX_MESSAGE_KBYTES: u32 = 50_000;
-const DEFAULT_QUEUED_MIN_MESSAGES: u32 = 10_000;
-
 #[derive(Debug, Clone)]
 pub struct KafkaConfig {
     config_map: HashMap<String, String>,

--- a/src/backends/kafka/config.rs
+++ b/src/backends/kafka/config.rs
@@ -75,7 +75,7 @@ fn apply_override_params(
 
 #[cfg(test)]
 mod tests {
-    use super::{KafkaConfig, DEFAULT_QUEUED_MIN_MESSAGES};
+    use super::KafkaConfig;
     use rdkafka::config::ClientConfig as RdKafkaConfig;
     use std::collections::HashMap;
 
@@ -93,10 +93,6 @@ mod tests {
         );
 
         let rdkafka_config: RdKafkaConfig = config.into();
-        assert_eq!(
-            rdkafka_config.get("queued.min.messages"),
-            Some(&DEFAULT_QUEUED_MIN_MESSAGES.to_string()[..])
-        );
         assert_eq!(
             rdkafka_config.get("queued.max.messages.kbytes"),
             Some("1000000")

--- a/src/backends/kafka/config.rs
+++ b/src/backends/kafka/config.rs
@@ -37,14 +37,14 @@ impl KafkaConfig {
         config
             .config_map
             .insert("auto.offset.reset".to_string(), auto_offset_reset);
-        config.config_map.insert(
-            "queued.max.messages.kbytes".to_string(),
-            DEFAULT_QUEUED_MAX_MESSAGE_KBYTES.to_string(),
-        );
-        config.config_map.insert(
-            "queued.min.messages".to_string(),
-            DEFAULT_QUEUED_MIN_MESSAGES.to_string(),
-        );
+        //config.config_map.insert(
+        //    "queued.max.messages.kbytes".to_string(),
+        //    DEFAULT_QUEUED_MAX_MESSAGE_KBYTES.to_string(),
+        //);
+        //config.config_map.insert(
+        //    "queued.min.messages".to_string(),
+        //    DEFAULT_QUEUED_MIN_MESSAGES.to_string(),
+        //);
 
         apply_override_params(config, override_params)
     }

--- a/src/backends/kafka/config.rs
+++ b/src/backends/kafka/config.rs
@@ -37,14 +37,6 @@ impl KafkaConfig {
         config
             .config_map
             .insert("auto.offset.reset".to_string(), auto_offset_reset);
-        //config.config_map.insert(
-        //    "queued.max.messages.kbytes".to_string(),
-        //    DEFAULT_QUEUED_MAX_MESSAGE_KBYTES.to_string(),
-        //);
-        //config.config_map.insert(
-        //    "queued.min.messages".to_string(),
-        //    DEFAULT_QUEUED_MIN_MESSAGES.to_string(),
-        //);
 
         apply_override_params(config, override_params)
     }

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -173,7 +173,7 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
         let mut config_obj: ClientConfig = self.config.clone().into();
 
         let consumer: BaseConsumer<CustomContext> = config_obj
-            .set_log_level(RDKafkaLogLevel::Debug)
+            .set_log_level(RDKafkaLogLevel::Warning)
             .create_with_context(context)?;
         let topic_str: Vec<&str> = topics.iter().map(|t| t.name.as_ref()).collect();
         consumer.subscribe(&topic_str)?;

--- a/src/backends/kafka/mod.rs
+++ b/src/backends/kafka/mod.rs
@@ -287,7 +287,7 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
 
         let consumer = self.consumer.as_mut().unwrap();
         let partitions = TopicPartitionList::from_topic_map(&topic_map).unwrap();
-        let _ = consumer.commit(&partitions, CommitMode::Sync).unwrap();
+        consumer.commit(&partitions, CommitMode::Sync).unwrap();
 
         // Clear staged offsets
         let cleared_map = HashMap::new();


### PR DESCRIPTION
There were two issues with the Arroyo Kafka consumer config:
- the log level was hard coded to Debug. All the streaming tests were done at Warning level
- The buffer config actually slows the test down a lot. To be investigated.